### PR TITLE
fix: Double get query for resource classes

### DIFF
--- a/src/AgGridExport.php
+++ b/src/AgGridExport.php
@@ -15,7 +15,7 @@ use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 
-class AgGridExport implements FromQuery, WithHeadings, WithColumnFormatting, ShouldAutoSize, WithMapping
+class AgGridExport implements FromQuery, ShouldAutoSize, WithColumnFormatting, WithHeadings, WithMapping
 {
     /**
      * @var Collection<string, AgGridColumnDefinition>

--- a/src/AgGridQueryBuilder.php
+++ b/src/AgGridQueryBuilder.php
@@ -356,15 +356,15 @@ class AgGridQueryBuilder implements Responsable
     protected function isJsonColumn(string $column): bool
     {
         return str_contains($column, '.') || $this->subject->getModel()->hasCast($column, [
-                'array',
-                'json',
-                'object',
-                'collection',
-                'encrypted:array',
-                'encrypted:collection',
-                'encrypted:json',
-                'encrypted:object',
-            ]);
+            'array',
+            'json',
+            'object',
+            'collection',
+            'encrypted:array',
+            'encrypted:collection',
+            'encrypted:json',
+            'encrypted:object',
+        ]);
     }
 
     protected function toJsonPath(string $key): string

--- a/src/AgGridQueryBuilder.php
+++ b/src/AgGridQueryBuilder.php
@@ -151,10 +151,10 @@ class AgGridQueryBuilder implements Responsable
             $resourceClass = $this->resourceClass;
             if (is_a($resourceClass, ResourceCollection::class, true)) {
                 // the resource is already a collection
-                $data = new $resourceClass($this->get());
+                $data = new $resourceClass($data);
             } else {
                 // wrap in an anonymous collection
-                $data = $resourceClass::collection($this->get());
+                $data = $resourceClass::collection($data);
             }
         }
 
@@ -356,15 +356,15 @@ class AgGridQueryBuilder implements Responsable
     protected function isJsonColumn(string $column): bool
     {
         return str_contains($column, '.') || $this->subject->getModel()->hasCast($column, [
-            'array',
-            'json',
-            'object',
-            'collection',
-            'encrypted:array',
-            'encrypted:collection',
-            'encrypted:json',
-            'encrypted:object',
-        ]);
+                'array',
+                'json',
+                'object',
+                'collection',
+                'encrypted:array',
+                'encrypted:collection',
+                'encrypted:json',
+                'encrypted:object',
+            ]);
     }
 
     protected function toJsonPath(string $key): string

--- a/tests/TestClasses/Models/Flamingo.php
+++ b/tests/TestClasses/Models/Flamingo.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class Flamingo extends Model implements AgGridExportable, AgGridCustomFilterable
+class Flamingo extends Model implements AgGridCustomFilterable, AgGridExportable
 {
     use HasFactory;
     use SoftDeletes;


### PR DESCRIPTION
Currently, we execute the query and store the result but do not use the result when creating the resource instance.