### PR TITLE
feat: support Laravel 11 & 12

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,12 +11,12 @@ jobs:
     name: phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.2, 8.1]
-        laravel: [10.*]
+        php: [8.3, 8.2]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+          - laravel: 11.*
+            testbench: 9.*
+            carbon: ^2.63
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -39,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to `ag-grid-laravel` will be documented in this file.
 
 ## Unreleased
 
+- Added support for Laravel 11 & 12
 - Added support for nested relations in filters
 - Added support for set values handling
 
+## 0.2.1 (2023-10-5)
+
+- Fixed double query for resource classes
+
 ## 0.2.0 (2023-08-24)
 
-- Rename `$params` to `$filters` in `AgGridCustomFilterable` 
+- Rename `$params` to `$filters` in `AgGridCustomFilterable`
 
 ## 0.1.0 (2023-08-24)
 

--- a/composer.json
+++ b/composer.json
@@ -21,22 +21,22 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/contracts": "^10.0",
+        "php": "^8.1|^8.2|^8.3|^8.4",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
         "maatwebsite/excel": "^3.1",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "nunomaduro/collision": "^7.8|^8.1",
+        "larastan/larastan": "^2.0.1|^3.0",
+        "orchestra/testbench": "^8.8|^9.0|^10.0",
+        "pestphp/pest": "^2.0|^3.0",
+        "pestphp/pest-plugin-arch": "^2.0|^3.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/phpstan-phpunit": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/demo/app/Models/Flamingo.php
+++ b/demo/app/Models/Flamingo.php
@@ -67,17 +67,17 @@ class Flamingo extends Model implements AgGridCustomFilterable, AgGridExportable
             new AgGridColumnDefinition(
                 'is_hungry',
                 __('Is Hungry'),
-                new AgGridBooleanFormatter()
+                new AgGridBooleanFormatter
             ),
             new AgGridColumnDefinition(
                 'last_vaccinated_on',
                 __('Last Vaccinated'),
-                new AgGridDateFormatter(),
+                new AgGridDateFormatter,
             ),
             new AgGridColumnDefinition(
                 'preferred_food_types',
                 __('Preferred Food Types'),
-                new AgGridArrayFormatter(),
+                new AgGridArrayFormatter,
             ),
             new AgGridColumnDefinition(
                 'keeper_id',
@@ -88,12 +88,12 @@ class Flamingo extends Model implements AgGridCustomFilterable, AgGridExportable
             new AgGridColumnDefinition(
                 'created_at',
                 __('Created At'),
-                new AgGridDateTimeFormatter(),
+                new AgGridDateTimeFormatter,
             ),
             new AgGridColumnDefinition(
                 'updated_at',
                 __('Updated At'),
-                new AgGridDateTimeFormatter(),
+                new AgGridDateTimeFormatter,
             ),
         ];
     }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/src/AgGridColumnDefinition.php
+++ b/src/AgGridColumnDefinition.php
@@ -12,6 +12,5 @@ class AgGridColumnDefinition
         public ?AgGridValueFormatter $valueFormatter = null,
         public ?\Closure $valueGetter = null,
         public ?string $excelFormat = null
-    ) {
-    }
+    ) {}
 }

--- a/src/AgGridFormatterContext.php
+++ b/src/AgGridFormatterContext.php
@@ -6,7 +6,5 @@ use DateTimeZone;
 
 class AgGridFormatterContext
 {
-    public function __construct(public string $locale, public ?DateTimeZone $timezone = null)
-    {
-    }
+    public function __construct(public string $locale, public ?DateTimeZone $timezone = null) {}
 }

--- a/src/AgGridQueryBuilder.php
+++ b/src/AgGridQueryBuilder.php
@@ -403,10 +403,10 @@ class AgGridQueryBuilder implements Responsable
         };
     }
 
-    protected function traverse($model, $key, $default = null): Model
+    protected function traverse($model, $key): Model
     {
         if (is_array($model)) {
-            return Arr::get($model, $key, $default);
+            return Arr::get($model, $key);
         }
 
         if (is_null($key)) {
@@ -418,11 +418,7 @@ class AgGridQueryBuilder implements Responsable
         }
 
         foreach (explode('.', $key) as $segment) {
-            try {
-                $model = $model->$segment;
-            } catch (\Exception $e) {
-                return value($default);
-            }
+            $model = $model->$segment;
         }
 
         return $model;

--- a/src/AgGridQueryBuilder.php
+++ b/src/AgGridQueryBuilder.php
@@ -196,7 +196,6 @@ class AgGridQueryBuilder implements Responsable
 
         $clone = $this->clone();
         tap($clone->getQuery(), function (QueryBuilder $query) {
-            /** @phpstan-ignore-next-line */
             $query->limit = $query->offset = $query->orders = null;
             $query->cleanBindings(['order']);
         });
@@ -421,7 +420,7 @@ class AgGridQueryBuilder implements Responsable
         foreach (explode('.', $key) as $segment) {
             try {
                 $model = $model->$segment;
-            } catch (\Exception $e) { // @phpstan-ignore-line
+            } catch (\Exception $e) {
                 return value($default);
             }
         }

--- a/src/Data/AgGridSetValue.php
+++ b/src/Data/AgGridSetValue.php
@@ -7,8 +7,7 @@ class AgGridSetValue
     public function __construct(
         public readonly string|int $value,
         public readonly ?string $label = null,
-    ) {
-    }
+    ) {}
 
     public static function fromValue(string|int|null $value): ?self
     {

--- a/src/Formatters/AgGridArrayFormatter.php
+++ b/src/Formatters/AgGridArrayFormatter.php
@@ -7,9 +7,7 @@ use Clickbar\AgGrid\Contracts\AgGridValueFormatter;
 
 class AgGridArrayFormatter implements AgGridValueFormatter
 {
-    public function __construct(private readonly string $separator = ',', private readonly ?AgGridValueFormatter $itemFormatter = null)
-    {
-    }
+    public function __construct(private readonly string $separator = ',', private readonly ?AgGridValueFormatter $itemFormatter = null) {}
 
     public function format(AgGridFormatterContext $context, $value): ?string
     {

--- a/src/Support/Column.php
+++ b/src/Support/Column.php
@@ -31,7 +31,7 @@ class Column
         if ($hasPathAccessor) {
             $this->isJsonColumn = true;
         } else {
-            $model = collect($this->relations)->last()?->model ?? $this->baseModel;
+            $model = collect($this->relations)->last()->model ?? $this->baseModel;
             $colum = Str::before($this->name, '.');
 
             $this->isJsonColumn = $model->hasCast($colum, [

--- a/src/Support/RelationMetadata.php
+++ b/src/Support/RelationMetadata.php
@@ -9,6 +9,5 @@ class RelationMetadata
     public function __construct(
         public string $name,
         public Model $model,
-    ) {
-    }
+    ) {}
 }

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -19,7 +19,7 @@ it('handles excel exports correctly', function () {
         Flamingo::class,
     );
 
-    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request()));
+    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request));
 
     $response->assertDownload('export.xlsx');
 });
@@ -32,7 +32,7 @@ it('handles csv exports correctly', function () {
         Flamingo::class,
     );
 
-    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request()));
+    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request));
 
     $response->assertDownload('export.csv');
 });
@@ -45,7 +45,7 @@ it('handles tsv exports correctly', function () {
         Flamingo::class,
     );
 
-    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request()));
+    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request));
 
     $response->assertDownload('export.csv');
 });
@@ -59,7 +59,7 @@ it('only exports selected columns', function () {
         Flamingo::class,
     );
 
-    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request()));
+    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request));
 
     $response->assertDownload('export.csv');
 });
@@ -73,7 +73,7 @@ it('does not crash when a non-existing column is requested', function () {
         Flamingo::class,
     );
 
-    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request()));
+    $response = TestResponse::fromBaseResponse($queryBuilder->toResponse(new Request));
 
     $response->assertDownload('export.csv');
 });

--- a/tests/TestClasses/Models/Flamingo.php
+++ b/tests/TestClasses/Models/Flamingo.php
@@ -60,7 +60,7 @@ class Flamingo extends Model implements AgGridCustomFilterable, AgGridExportable
             new AgGridColumnDefinition(
                 'species',
                 __('Species'),
-                new AgGridBackedEnumFormatter(),
+                new AgGridBackedEnumFormatter,
             ),
             new AgGridColumnDefinition(
                 'weight',
@@ -69,17 +69,17 @@ class Flamingo extends Model implements AgGridCustomFilterable, AgGridExportable
             new AgGridColumnDefinition(
                 'is_hungry',
                 __('Is Hungry'),
-                new AgGridBooleanFormatter()
+                new AgGridBooleanFormatter
             ),
             new AgGridColumnDefinition(
                 'last_vaccinated_on',
                 __('Last Vaccinated'),
-                new AgGridDateFormatter(),
+                new AgGridDateFormatter,
             ),
             new AgGridColumnDefinition(
                 'preferred_food_types',
                 __('Preferred Food Types'),
-                new AgGridArrayFormatter(),
+                new AgGridArrayFormatter,
             ),
             new AgGridColumnDefinition(
                 'keeper_id',
@@ -90,12 +90,12 @@ class Flamingo extends Model implements AgGridCustomFilterable, AgGridExportable
             new AgGridColumnDefinition(
                 'created_at',
                 __('Created At'),
-                new AgGridDateTimeFormatter(),
+                new AgGridDateTimeFormatter,
             ),
             new AgGridColumnDefinition(
                 'updated_at',
                 __('Updated At'),
-                new AgGridDateTimeFormatter(),
+                new AgGridDateTimeFormatter,
             ),
         ];
     }


### PR DESCRIPTION
Upgrades package dependency requirements to allow installation in Laravel 11 & 12 environments.

This also addresses some newer phpstan issues, where phpstan knows about specific types now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Laravel 11 and 12.

* **Chores**
  * Updated GitHub Actions workflows to the latest version.
  * Expanded PHP version support (now 8.1 through 8.4).
  * Broadened dependency version constraints to accommodate multiple Laravel and library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->